### PR TITLE
Add rawxml policy sample

### DIFF
--- a/example/product-unlimited/product-unlimited.policy.xml
+++ b/example/product-unlimited/product-unlimited.policy.xml
@@ -1,6 +1,5 @@
 <policies>
     <inbound>
-        <rate-limit calls="3" renewal-period="10" />
         <base />
     </inbound>
     <outbound>

--- a/example/product-unlimited/product-unlimited.template.json
+++ b/example/product-unlimited/product-unlimited.template.json
@@ -7,18 +7,24 @@
             "metadata": {
                 "description": "The name of the API Management"
             }
+        },
+        "repoBaseUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "Base URL of the repository"
+            }
         }
     },
     "variables": {},
     "resources": [
         {
             "type": "Microsoft.ApiManagement/service/products",
-            "name": "[concat(parameters('ApimServiceName'), '/starter')]",
+            "name": "[concat(parameters('ApimServiceName'), '/unlimited')]",
             "apiVersion": "2018-01-01",
             "scale": null,
             "properties": {
-                "displayName": "Starter",
-                "description": "Include 3 APIs. Limited to 1 subscription per developer. Throttled at 3 calls per 10 second.",
+                "displayName": "Unlimited",
+                "description": "Subscribers have completely unlimited access to the API. Administrator approval is required.",
                 "terms": null,
                 "subscriptionRequired": true,
                 "approvalRequired": true,
@@ -28,24 +34,24 @@
         },
         {
             "type": "Microsoft.ApiManagement/service/products/policies",
-            "name": "[concat(parameters('ApimServiceName'), '/starter/policy')]",
+            "name": "[concat(parameters('ApimServiceName'), '/unlimited/policy')]",
             "apiVersion": "2018-01-01",
             "properties": {
-                "policyContent": "<policies><inbound><rate-limit calls=\"3\" renewal-period=\"10\" /><base /></inbound><outbound><base /></outbound><backend><base /></backend><on-error><base /></on-error></policies>",
-                "contentFormat": "rawxml"
+                "policyContent": "[concat(parameters('repoBaseUrl'), '/product-starter/product-starter.policy.xml')]",
+                "contentFormat": "xml-link"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.ApiManagement/service/products', parameters('ApimServiceName'), 'starter')]"
+                "[resourceId('Microsoft.ApiManagement/service/products', parameters('ApimServiceName'), 'unlimited')]"
             ]
         },
         {
             "type": "Microsoft.ApiManagement/service/products/groups",
-            "name": "[concat(parameters('ApimServiceName'), '/starter/contosogroup' )]",
+            "name": "[concat(parameters('ApimServiceName'), '/unlimited/contosogroup' )]",
             "apiVersion": "2017-03-01",
             "scale": null,
             "properties": {},
             "dependsOn": [
-                "[resourceId('Microsoft.ApiManagement/service/products', parameters('ApimServiceName'), 'starter')]"
+                "[resourceId('Microsoft.ApiManagement/service/products', parameters('ApimServiceName'), 'unlimited')]"
             ]
         }
     ],


### PR DESCRIPTION
This PR aims to add a new product showcasing how policy XMLs can be made inline into the template itself.

I have an added a product named `Unlimited` (mimicking the default product usually created) which had a rather simple policy XML content. (again like the default)

So, I swapped the product policy's `contentFormat` with the existing product so as to showcase a "JSON escaped XML" (Refer this [line](https://github.com/PramodValavala-MSFT/azure-api-management-devops-example/blob/add-rawxml-sample/example/product-starter/product-starter.template.json#L34))