### PR TITLE
Examples for OAuth and OpenID Connect providers

### DIFF
--- a/example/Security/README.md
+++ b/example/Security/README.md
@@ -1,0 +1,7 @@
+# API Management : Security
+
+## OAuth2 & OpenID Connect
+
+APIM supports adding OAuth 2.0 and OpenID Connect servers which can be used to protect APIs with.
+
+The template examples present in this folder are based on the [tutorial](https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad) present in the docs.

--- a/example/Security/oauth2.template.json
+++ b/example/Security/oauth2.template.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "ApimServiceName": {
+            "type": "string"
+        },
+        "frontendClientID": {
+            "type": "string"
+        },
+        "frontendClientSecret": {
+            "type": "string"
+        },
+        "backendClientID": {
+            "type": "string"
+        },
+        "authorizationEndpoint": {
+            "type": "string"
+        },
+        "tokenEndpoint": {
+            "type": "string"
+        },
+        "clientRegistrationEndpoint": {
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.ApiManagement/service/authorizationServers",
+            "name": "[concat(parameters('ApimServiceName'), '/', 'client-app')]",
+            "apiVersion": "2018-01-01",
+            "properties": {
+                "displayName": "Azure AD",
+                "clientRegistrationEndpoint": "[parameters('clientRegistrationEndpoint')]",
+                "authorizationEndpoint": "[parameters('authorizationEndpoint')]",
+                "authorizationMethods": ["GET"],
+                "clientAuthenticationMethod": ["Body"],
+                "tokenBodyParameters": [
+                    {
+                        "name": "resource",
+                        "value": "[parameters('backendClientID')]"
+                    }
+                ],
+                "tokenEndpoint": "[parameters('tokenEndpoint')]",
+                "grantTypes": ["authorizationCode"],
+                "bearerTokenSendingMethods": ["authorizationHeader"],
+                "clientId": "[parameters('frontendClientID')]",
+                "clientSecret": "[parameters('frontendClientSecret')]"
+            }
+        }
+    ]
+}

--- a/example/Security/openid.template.json
+++ b/example/Security/openid.template.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "ApimServiceName": {
+            "type": "string"
+        },
+        "clientID": {
+            "type": "string"
+        },
+        "clientSecret": {
+            "type": "string"
+        },
+        "metadataEndpoint": {
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.ApiManagement/service/openidConnectProviders",
+            "name": "[concat(parameters('ApimServiceName'), '/', 'client-app')]",
+            "apiVersion": "2018-01-01",
+            "properties": {
+                "displayName": "Azure AD",
+                "metadataEndpoint": "[parameters('metadataEndpoint')]",
+                "clientId": "[parameters('clientID')]",
+                "clientSecret": "[parameters('clientSecret')]"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The examples are based on the [tutorial](https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad) present in the docs and can be used along side with it.

All the Azure AD related configuration required for these templates can be followed as is from the doc.
Hence, the reason for using `client-app` for the names of both the resources.